### PR TITLE
Rework errors

### DIFF
--- a/alchemist.toml
+++ b/alchemist.toml
@@ -14,7 +14,6 @@ args = ["shell-complete"]
 [tasks.install]
 serial_tasks = ["cargo_install", "generate_shell_completions"]
 
-
 [tasks.clean]
 command = "cargo"
 args = ["clean"]

--- a/src/cli/terminal.rs
+++ b/src/cli/terminal.rs
@@ -33,9 +33,9 @@ pub fn error(err: crate::error::AlchemistError) {
         "{}{}{}{}{}",
         message_prefix(ERROR.red().bold()),
         "[".dimmed(),
-        err.error_type.to_string().dimmed().italic(),
+        err.kind().dimmed().italic(),
         "]: ".dimmed(),
-        err.error_message
+        err.inner()
     )
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,47 +1,44 @@
-#[derive(Debug, PartialEq, Eq)]
-pub enum AlchemistErrorType {
-    NoConfigFileError,
-    ConfigParseError,
-    CommandFailedError,
-    InvalidSerialTask,
-    CurrentDirIsInvalid,
-    CLIError,
-}
-
-impl AlchemistErrorType {
-    pub fn with_message<S: ToString>(self, message: S) -> AlchemistError {
-        AlchemistError {
-            error_type: self,
-            error_message: message.to_string(),
-        }
-    }
-
-    pub fn build_result<T, S: ToString>(self, message: S) -> Result<T> {
-        Err(AlchemistError {
-            error_type: self,
-            error_message: message.to_string(),
-        })
-    }
-}
-
-impl ToString for AlchemistErrorType {
-    fn to_string(&self) -> String {
-        match self {
-            Self::NoConfigFileError => "NoConfigFileError",
-            Self::ConfigParseError => "ConfigParseError",
-            Self::CommandFailedError => "CommandFailedError",
-            Self::InvalidSerialTask => "InvalidSerialTask",
-            Self::CurrentDirIsInvalid => "CurrentDirIsInvalid",
-            Self::CLIError => "CLIError",
-        }
-        .to_string()
-    }
-}
-
 #[derive(Debug)]
-pub struct AlchemistError {
-    pub error_type: AlchemistErrorType,
-    pub error_message: String,
+pub enum AlchemistError {
+    NoConfigFileError(String),
+    ConfigParseError(String),
+    CommandFailedError(String),
+    InvalidSerialTask(String),
+    CurrentDirIsInvalid(String),
+    CLIError(String),
+}
+
+impl AlchemistError {
+    pub fn kind(&self) -> String {
+        match self {
+            Self::NoConfigFileError(_) => "NoConfigFileError",
+            Self::ConfigParseError(_) => "ConfigParseError",
+            Self::CommandFailedError(_) => "CommandFailedError",
+            Self::InvalidSerialTask(_) => "InvalidSerialTask",
+            Self::CurrentDirIsInvalid(_) => "CurrentDirIsInvalid",
+            Self::CLIError(_) => "CLIError",
+        }
+        .into()
+    }
+
+    pub fn inner(&self) -> String {
+        // should be able to do this easier
+        match self {
+            Self::NoConfigFileError(e) => e,
+            Self::ConfigParseError(e) => e,
+            Self::CommandFailedError(e) => e,
+            Self::InvalidSerialTask(e) => e,
+            Self::CurrentDirIsInvalid(e) => e,
+            Self::CLIError(e) => e,
+        }
+        .clone()
+    }
+}
+
+impl Into<String> for AlchemistError {
+    fn into(self) -> String {
+        format!("{}({})", self.kind(), self.inner())
+    }
 }
 
 pub type Result<T> = std::result::Result<T, AlchemistError>;


### PR DESCRIPTION
This is a start that allows for further refactoring in the future if we decide to change some of the enum values.

doing this in the future allows any error to be implicitly converted without really having to think about what you are dealing with and still getting useful error info.