### PR TITLE
Use IndexMap to keep the config order of tasks:

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ version = "0.3.6"
 dependencies = [
  "clap",
  "clap_complete",
+ "indexmap",
  "owo-colors",
  "serde",
  "tempfile",
@@ -187,6 +188,7 @@ checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ description = "Task runner and build tool written in Rust"
 [dependencies]
 clap = { version = "4.5.37", features = ["derive"] }
 clap_complete = "4.5.48"
+indexmap = { version = "2.9.0", features = ["serde"] }
 owo-colors = "4.2.0"
 serde = { version = "1.0.219", features = ["derive"] }
 terminal_size = "0.4.2"

--- a/src/cli/interface.rs
+++ b/src/cli/interface.rs
@@ -157,8 +157,6 @@ pub(crate) fn list_available_tasks(verbose: u8) -> Result<()> {
         .map(|(k, v)| (k, v.describe()))
         .collect::<Vec<(&String, TaskDescription)>>();
 
-    task_names.sort_by_key(|(k, _)| *k);
-
     println!(" ┌──────────────────┐");
     println!(" │ Available tasks: │");
     println!(" ├──────────────────┘");

--- a/src/cli/interface.rs
+++ b/src/cli/interface.rs
@@ -150,7 +150,7 @@ pub(crate) fn list_available_tasks(verbose: u8) -> Result<()> {
     }
 
     // Filtering of hidden tasks unless verbose flag(s) are given.
-    let mut task_names = alchemist_config
+    let task_names = alchemist_config
         .tasks
         .iter()
         .filter(|(_, v)| v.is_shown() || verbose >= 1)

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,8 +4,10 @@ mod config_test;
 
 use std::env::{current_dir, set_current_dir};
 
+use std::fs;
 use std::path::PathBuf;
-use std::{collections::HashMap, fs};
+
+use indexmap::IndexMap;
 
 use serde::Deserialize;
 
@@ -28,7 +30,7 @@ pub const CONFIG_FILE: &str = "alchemist.toml";
 /// ```
 pub struct AlchemistConfig {
     /// Contains a map of tasks that can be of multiple task types
-    pub tasks: HashMap<String, AlchemistTaskType>,
+    pub tasks: IndexMap<String, AlchemistTaskType>,
 }
 
 pub fn locate_config() -> Result<PathBuf> {

--- a/src/tasks_test.rs
+++ b/src/tasks_test.rs
@@ -2,6 +2,8 @@ use super::*;
 
 use crate::error::ErrorContext;
 
+use indexmap::IndexMap;
+
 //
 // BasicTask tests:
 //
@@ -17,7 +19,7 @@ fn basic_task() {
     let ret = basic.run(
         "name",
         &AlchemistConfig {
-            tasks: HashMap::new(),
+            tasks: IndexMap::new(),
         },
     );
     assert_eq!(ret, Result::Ok(()));
@@ -42,7 +44,7 @@ fn basic_task_env_vars() {
     let ret = basic.run(
         "name",
         &AlchemistConfig {
-            tasks: HashMap::new(),
+            tasks: IndexMap::new(),
         },
     );
 
@@ -64,7 +66,7 @@ fn basic_task_nonzero_exit_code() {
     let ret = basic.run(
         "name",
         &AlchemistConfig {
-            tasks: HashMap::new(),
+            tasks: IndexMap::new(),
         },
     );
     assert_eq!(
@@ -90,7 +92,7 @@ fn basic_task_spawn_failure() {
     let ret = basic.run(
         "name",
         &AlchemistConfig {
-            tasks: HashMap::new(),
+            tasks: IndexMap::new(),
         },
     );
     let alchem_err = ret.as_ref().err().unwrap();
@@ -120,7 +122,7 @@ fn shell_task() {
     let ret = shell.run(
         "name",
         &AlchemistConfig {
-            tasks: HashMap::new(),
+            tasks: IndexMap::new(),
         },
     );
     assert_eq!(ret, Result::Ok(()));
@@ -135,7 +137,7 @@ fn shell_task_nonzero_exit_code() {
     let ret = shell.run(
         "name",
         &AlchemistConfig {
-            tasks: HashMap::new(),
+            tasks: IndexMap::new(),
         },
     );
     assert_eq!(
@@ -160,7 +162,7 @@ fn serial_task_empty() {
     let ret = serial.run(
         "name",
         &AlchemistConfig {
-            tasks: HashMap::new(),
+            tasks: IndexMap::new(),
         },
     );
     assert!(ret.is_ok());
@@ -174,7 +176,7 @@ fn serial_tasks_ok() {
         serial_tasks: vec!["one".to_string(), "two".to_string()],
         hide: None,
     };
-    let mut tasks: HashMap<String, AlchemistTaskType> = HashMap::new();
+    let mut tasks: IndexMap<String, AlchemistTaskType> = IndexMap::new();
 
     tasks.insert(
         "one".to_string(),
@@ -217,7 +219,7 @@ fn test_serial_task_one_fail() {
         serial_tasks: vec!["one".to_string(), "two".to_string()],
         hide: None,
     };
-    let mut tasks: HashMap<String, AlchemistTaskType> = HashMap::new();
+    let mut tasks: IndexMap<String, AlchemistTaskType> = IndexMap::new();
     tasks.insert(
         "one".to_string(),
         AlchemistBasicTask {
@@ -264,7 +266,7 @@ fn parallel_task_empty() {
     let ret = parallel.run(
         "name",
         &AlchemistConfig {
-            tasks: HashMap::new(),
+            tasks: IndexMap::new(),
         },
     );
     assert!(ret.is_ok());
@@ -276,7 +278,7 @@ fn parallel_tasks_one_fail() {
         parallel_tasks: vec!["one".to_string(), "two".to_string()],
         hide: None,
     };
-    let mut tasks: HashMap<String, AlchemistTaskType> = HashMap::new();
+    let mut tasks: IndexMap<String, AlchemistTaskType> = IndexMap::new();
     tasks.insert(
         "one".to_string(),
         AlchemistBasicTask {
@@ -315,7 +317,7 @@ fn parallel_tasks_actually_run_parallel() {
         parallel_tasks: vec!["one".to_string(), "two".to_string()],
         hide: None,
     };
-    let mut tasks: HashMap<String, AlchemistTaskType> = HashMap::new();
+    let mut tasks: IndexMap<String, AlchemistTaskType> = IndexMap::new();
 
     tasks.insert(
         "one".to_string(),


### PR DESCRIPTION
And use that in `--list` i.s.o. sorting by name (for deterministic ordering).

Idea here is to make the list-of-tasks easy to read logically (assuming a sensible ordering in the file) and across alchemist output & config-file on disk.